### PR TITLE
fix:ハンドサインデータは取得後上書き

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -133,7 +133,7 @@ onMounted(async () => {
       remoteVersion.value.publish > localVersion.value.publish
 
     if (needUpdate) {
-      // ハンドサインデータは一括取得
+      // ハンドサインデータは一括取得一括更新
       // 今日の日付のyyyymmdd形式で取得
       const today = new Date()
       const todayStr = today.toISOString().split('T')[0].replace(/-/g, '')

--- a/frontend/utils/indexedDb.ts
+++ b/frontend/utils/indexedDb.ts
@@ -147,10 +147,7 @@ export async function getMasterData(key: string): Promise<any[] | undefined> {
  */
 export async function saveHaMasterData(key: string, data: any[]): Promise<void> {
   const db = await getDb()
-  const rec = await db.get('masterDataHa', key)
-  const existing: any[] = rec?.value ?? []
-  const merged = [...existing, ...data]
-  await db.put('masterDataHa', { key, value: merged })
+  await db.put('masterDataHa', { key, value: data })
 }
 
 /**


### PR DESCRIPTION
データメンテの都合上でversionを上げたとき、ハンドサインが差分更新だとめんどくさいので、
どうせそんなに数ないしまるっと置き換えで良いかなって修正